### PR TITLE
Add null safety support

### DIFF
--- a/example/lib/component_page.dart
+++ b/example/lib/component_page.dart
@@ -48,7 +48,7 @@ class ComponentPage extends StatelessWidget {
               gradient: LinearGradient(
                 begin: Alignment.topCenter,
                 end: Alignment.bottomCenter,
-                colors: [Colors.blue, Colors.lightBlueAccent[100]],
+                colors: [Colors.blue, Colors.lightBlueAccent.shade100],
               ),
             ),
           ),
@@ -348,8 +348,8 @@ class ComponentPage extends StatelessWidget {
 
 class _ComponentRow extends TableRow {
   _ComponentRow({
-    String name,
-    Widget item,
+    required String name,
+    required Widget item,
   }) : super(
           children: [
             _ComponentName(name),
@@ -360,10 +360,9 @@ class _ComponentRow extends TableRow {
 
 class _ComponentItem extends StatelessWidget {
   const _ComponentItem({
-    Key key,
-    @required this.child,
-  })  : assert(child != null),
-        super(key: key);
+    Key? key,
+    required this.child,
+  }) : super(key: key);
 
   final Widget child;
 
@@ -383,8 +382,8 @@ class _ComponentItem extends StatelessWidget {
 class _ComponentName extends StatelessWidget {
   const _ComponentName(
     this.name, {
-    Key key,
-  })  : assert(name != null && name.length > 0),
+    Key? key,
+  })  : assert(name.length > 0),
         super(key: key);
 
   final String name;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,7 +23,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData.light(),
       darkTheme: ThemeData.dark(),
       onGenerateRoute: (settings) {
-        String path = Uri.tryParse(settings.name)?.path;
+        String? path = Uri.tryParse(settings.name!)?.path;
         Widget child;
         switch (path) {
           case '/theme':
@@ -51,8 +51,8 @@ class MyApp extends StatelessWidget {
 
 class HomePage extends StatefulWidget {
   HomePage({
-    Key key,
-    @required this.child,
+    Key? key,
+    required this.child,
   }) : super(key: key);
 
   final Widget child;
@@ -77,7 +77,7 @@ class _HomePageState extends State<HomePage> {
     return WillPopScope(
       onWillPop: () async {
         if (_navigatorKey.currentState?.canPop() ?? false) {
-          _navigatorKey.currentState.maybePop();
+          _navigatorKey.currentState?.maybePop();
           return false;
         } else {
           return true;
@@ -152,13 +152,13 @@ class ExamplePage extends StatelessWidget {
 
 class _NavigationCard extends StatelessWidget {
   const _NavigationCard({
-    Key key,
-    @required this.name,
+    Key? key,
+    required this.name,
     this.navigationBuilder,
   }) : super(key: key);
 
   final String name;
-  final NavigateWidgetBuilder navigationBuilder;
+  final NavigateWidgetBuilder? navigationBuilder;
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/showcase/package_delivery_tracking.dart
+++ b/example/lib/showcase/package_delivery_tracking.dart
@@ -47,10 +47,9 @@ class PackageDeliveryTrackingPage extends StatelessWidget {
 
 class _OrderTitle extends StatelessWidget {
   const _OrderTitle({
-    Key key,
-    @required this.orderInfo,
-  })  : assert(orderInfo != null),
-        super(key: key);
+    Key? key,
+    required this.orderInfo,
+  }) : super(key: key);
 
   final _OrderInfo orderInfo;
 
@@ -78,7 +77,7 @@ class _OrderTitle extends StatelessWidget {
 
 class _InnerTimeline extends StatelessWidget {
   const _InnerTimeline({
-    @required this.messages,
+    required this.messages,
   });
 
   final List<_DeliveryMessage> messages;
@@ -103,13 +102,14 @@ class _InnerTimeline extends StatelessWidget {
               ),
         ),
         builder: TimelineTileBuilder(
-          indicatorBuilder: (_, index) =>
-              !isEdgeIndex(index) ? Indicator.outlined(borderWidth: 1.0) : null,
+          indicatorBuilder: (_, index) => !isEdgeIndex(index)
+              ? Indicator.outlined(borderWidth: 1.0)
+              : const SizedBox(),
           startConnectorBuilder: (_, index) => Connector.solidLine(),
           endConnectorBuilder: (_, index) => Connector.solidLine(),
           contentsBuilder: (_, index) {
             if (isEdgeIndex(index)) {
-              return null;
+              return const SizedBox();
             }
 
             return Padding(
@@ -119,7 +119,7 @@ class _InnerTimeline extends StatelessWidget {
           },
           itemExtentBuilder: (_, index) => isEdgeIndex(index) ? 10.0 : 30.0,
           nodeItemOverlapBuilder: (_, index) =>
-              isEdgeIndex(index) ? true : null,
+              isEdgeIndex(index) ? true : false,
           itemCount: messages.length + 2,
         ),
       ),
@@ -128,9 +128,8 @@ class _InnerTimeline extends StatelessWidget {
 }
 
 class _DeliveryProcesses extends StatelessWidget {
-  const _DeliveryProcesses({Key key, @required this.processes})
-      : assert(processes != null),
-        super(key: key);
+  const _DeliveryProcesses({Key? key, required this.processes})
+      : super(key: key);
 
   final List<_DeliveryProcess> processes;
   @override
@@ -158,7 +157,7 @@ class _DeliveryProcesses extends StatelessWidget {
             connectionDirection: ConnectionDirection.before,
             itemCount: processes.length,
             contentsBuilder: (_, index) {
-              if (processes[index].isCompleted) return null;
+              if (processes[index].isCompleted) return const SizedBox();
 
               return Padding(
                 padding: EdgeInsets.only(left: 8.0),
@@ -204,9 +203,7 @@ class _DeliveryProcesses extends StatelessWidget {
 }
 
 class _OnTimeBar extends StatelessWidget {
-  const _OnTimeBar({Key key, @required this.driver})
-      : assert(driver != null),
-        super(key: key);
+  const _OnTimeBar({Key? key, required this.driver}) : super(key: key);
 
   final _DriverInfo driver;
 
@@ -217,7 +214,7 @@ class _OnTimeBar extends StatelessWidget {
         Builder(
           builder: (context) => MaterialButton(
             onPressed: () {
-              Scaffold.of(context).showSnackBar(
+              ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
                   content: Text('On-time!'),
                 ),
@@ -283,10 +280,10 @@ _OrderInfo _data(int id) => _OrderInfo(
 
 class _OrderInfo {
   const _OrderInfo({
-    @required this.id,
-    @required this.date,
-    @required this.driverInfo,
-    @required this.deliveryProcesses,
+    required this.id,
+    required this.date,
+    required this.driverInfo,
+    required this.deliveryProcesses,
   });
 
   final int id;
@@ -297,8 +294,8 @@ class _OrderInfo {
 
 class _DriverInfo {
   const _DriverInfo({
-    @required this.name,
-    this.thumbnailUrl,
+    required this.name,
+    required this.thumbnailUrl,
   });
 
   final String name;

--- a/example/lib/showcase/package_delivery_tracking.dart
+++ b/example/lib/showcase/package_delivery_tracking.dart
@@ -102,14 +102,13 @@ class _InnerTimeline extends StatelessWidget {
               ),
         ),
         builder: TimelineTileBuilder(
-          indicatorBuilder: (_, index) => !isEdgeIndex(index)
-              ? Indicator.outlined(borderWidth: 1.0)
-              : const SizedBox(),
+          indicatorBuilder: (_, index) =>
+              !isEdgeIndex(index) ? Indicator.outlined(borderWidth: 1.0) : null,
           startConnectorBuilder: (_, index) => Connector.solidLine(),
           endConnectorBuilder: (_, index) => Connector.solidLine(),
           contentsBuilder: (_, index) {
             if (isEdgeIndex(index)) {
-              return const SizedBox();
+              return null;
             }
 
             return Padding(
@@ -119,7 +118,7 @@ class _InnerTimeline extends StatelessWidget {
           },
           itemExtentBuilder: (_, index) => isEdgeIndex(index) ? 10.0 : 30.0,
           nodeItemOverlapBuilder: (_, index) =>
-              isEdgeIndex(index) ? true : false,
+              isEdgeIndex(index) ? true : null,
           itemCount: messages.length + 2,
         ),
       ),
@@ -157,7 +156,7 @@ class _DeliveryProcesses extends StatelessWidget {
             connectionDirection: ConnectionDirection.before,
             itemCount: processes.length,
             contentsBuilder: (_, index) {
-              if (processes[index].isCompleted) return const SizedBox();
+              if (processes[index].isCompleted) return null;
 
               return Padding(
                 padding: EdgeInsets.only(left: 8.0),
@@ -211,21 +210,19 @@ class _OnTimeBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        Builder(
-          builder: (context) => MaterialButton(
-            onPressed: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text('On-time!'),
-                ),
-              );
-            },
-            elevation: 0,
-            shape: StadiumBorder(),
-            color: Color(0xff66c97f),
-            textColor: Colors.white,
-            child: Text('On-time'),
-          ),
+        MaterialButton(
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('On-time!'),
+              ),
+            );
+          },
+          elevation: 0,
+          shape: StadiumBorder(),
+          color: Color(0xff66c97f),
+          textColor: Colors.white,
+          child: Text('On-time'),
         ),
         Spacer(),
         Text(

--- a/example/lib/showcase/process_timeline.dart
+++ b/example/lib/showcase/process_timeline.dart
@@ -156,7 +156,7 @@ class _ProcessTimelinePageState extends State<ProcessTimelinePage> {
                 );
               }
             } else {
-              return const SizedBox();
+              return null;
             }
           },
           itemCount: _processes.length,

--- a/example/lib/showcase/process_timeline.dart
+++ b/example/lib/showcase/process_timeline.dart
@@ -156,7 +156,7 @@ class _ProcessTimelinePageState extends State<ProcessTimelinePage> {
                 );
               }
             } else {
-              return null;
+              return const SizedBox();
             }
           },
           itemCount: _processes.length,
@@ -179,7 +179,7 @@ class _ProcessTimelinePageState extends State<ProcessTimelinePage> {
 /// TODO: Bezier curve into package component
 class _BezierPainter extends CustomPainter {
   const _BezierPainter({
-    @required this.color,
+    required this.color,
     this.drawStart = true,
     this.drawEnd = true,
   });

--- a/example/lib/showcase/process_timeline.dart
+++ b/example/lib/showcase/process_timeline.dart
@@ -134,13 +134,13 @@ class _ProcessTimelinePageState extends State<ProcessTimelinePage> {
               if (index == _processIndex) {
                 final prevColor = getColor(index - 1);
                 final color = getColor(index);
-                var gradientColors;
+                List<Color> gradientColors;
                 if (type == ConnectorType.start) {
-                  gradientColors = [Color.lerp(prevColor, color, 0.5), color];
+                  gradientColors = [Color.lerp(prevColor, color, 0.5)!, color];
                 } else {
                   gradientColors = [
                     prevColor,
-                    Color.lerp(prevColor, color, 0.5)
+                    Color.lerp(prevColor, color, 0.5)!
                   ];
                 }
                 return DecoratedLineConnector(

--- a/example/lib/showcase_page.dart
+++ b/example/lib/showcase_page.dart
@@ -68,12 +68,12 @@ class ShowcasePage extends StatelessWidget {
 
 class _ShowcaseCard extends StatelessWidget {
   const _ShowcaseCard({
-    Key key,
-    @required this.navigationBuilder,
-    @required this.image,
-    @required this.title,
-    @required this.designer,
-    @required this.url,
+    Key? key,
+    required this.navigationBuilder,
+    required this.image,
+    required this.title,
+    required this.designer,
+    required this.url,
   }) : super(key: key);
 
   final String image;

--- a/example/lib/theme_page.dart
+++ b/example/lib/theme_page.dart
@@ -19,7 +19,7 @@ class _ThemePageState extends State<ThemePage> {
     'ORANGE': Colors.orange,
   };
 
-  TimelineThemeData _theme;
+  late TimelineThemeData _theme;
 
   @override
   void initState() {
@@ -83,7 +83,7 @@ class _ThemePageState extends State<ThemePage> {
                           'Horizontal': Axis.horizontal,
                         },
                         value: _theme.direction,
-                        onChanged: (axis) {
+                        onChanged: (Axis? axis) {
                           if (_theme.direction != axis) {
                             setState(() {
                               _updateTheme(_theme.copyWith(direction: axis));
@@ -95,7 +95,7 @@ class _ThemePageState extends State<ThemePage> {
                         title: 'Color',
                         items: _themeColors,
                         value: _theme.color,
-                        onChanged: (color) {
+                        onChanged: (Color? color) {
                           _updateTheme(_theme.copyWith(color: color));
                         },
                       ),
@@ -142,7 +142,7 @@ class _ThemePageState extends State<ThemePage> {
                         'IndicatorTheme',
                         style: Theme.of(context).textTheme.headline6,
                       ),
-                      _ThemeDropdown(
+                      _ThemeDropdown<Color?>(
                         title: 'Color',
                         items: _themeColors,
                         value: _theme.indicatorTheme.color,
@@ -158,7 +158,7 @@ class _ThemePageState extends State<ThemePage> {
                       SizedBox(height: 10.0),
                       _ThemeSlider(
                         title: 'Position',
-                        value: _theme.indicatorTheme.position,
+                        value: _theme.indicatorTheme.position ?? 0,
                         onChanged: (position) {
                           _updateTheme(
                             _theme.copyWith(
@@ -170,7 +170,7 @@ class _ThemePageState extends State<ThemePage> {
                       ),
                       _ThemeSlider(
                         title: 'Size',
-                        value: _theme.indicatorTheme.size,
+                        value: _theme.indicatorTheme.size ?? 0,
                         max: 100.0,
                         onChanged: (size) {
                           _updateTheme(
@@ -194,7 +194,7 @@ class _ThemePageState extends State<ThemePage> {
                         'ConnectorTheme',
                         style: Theme.of(context).textTheme.headline6,
                       ),
-                      _ThemeDropdown(
+                      _ThemeDropdown<Color?>(
                         title: 'Color',
                         items: _themeColors,
                         value: _theme.connectorTheme.color,
@@ -210,7 +210,7 @@ class _ThemePageState extends State<ThemePage> {
                       SizedBox(height: 10.0),
                       _ThemeSlider(
                         title: 'Space',
-                        value: _theme.connectorTheme.space,
+                        value: _theme.connectorTheme.space ?? 0,
                         max: 100,
                         onChanged: (space) {
                           _updateTheme(
@@ -223,7 +223,7 @@ class _ThemePageState extends State<ThemePage> {
                       ),
                       _ThemeSlider(
                         title: 'Indent',
-                        value: _theme.connectorTheme.indent,
+                        value: _theme.connectorTheme.indent ?? 0,
                         max: 22,
                         onChanged: (indent) {
                           _updateTheme(
@@ -236,7 +236,7 @@ class _ThemePageState extends State<ThemePage> {
                       ),
                       _ThemeSlider(
                         title: 'Thickness',
-                        value: _theme.connectorTheme.thickness,
+                        value: _theme.connectorTheme.thickness ?? 0,
                         max: 100,
                         onChanged: (thickness) {
                           _updateTheme(
@@ -287,17 +287,17 @@ class _ThemePageState extends State<ThemePage> {
 
 class _ThemeDropdown<T> extends StatelessWidget {
   const _ThemeDropdown({
-    Key key,
-    @required this.title,
-    @required this.items,
-    @required this.value,
-    @required this.onChanged,
+    Key? key,
+    required this.title,
+    required this.items,
+    required this.value,
+    required this.onChanged,
   }) : super(key: key);
 
   final String title;
   final Map<String, T> items;
   final T value;
-  final ValueChanged<T> onChanged;
+  final ValueChanged<T?> onChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -322,15 +322,15 @@ class _ThemeDropdown<T> extends StatelessWidget {
 
 class _ThemeSlider extends StatelessWidget {
   const _ThemeSlider({
-    Key key,
-    @required this.title,
-    @required this.value,
-    @required this.onChanged,
+    Key? key,
+    required this.title,
+    required this.value,
+    required this.onChanged,
     this.max = 1.0,
   }) : super(key: key);
 
   final String title;
-  final double value;
+  final double? value;
   final ValueChanged<double> onChanged;
   final double max;
 
@@ -339,8 +339,8 @@ class _ThemeSlider extends StatelessWidget {
     var label;
     if (value == null) {
       label = '';
-    } else if (value > 1) {
-      label = value.toInt().toString();
+    } else if (value! > 1) {
+      label = value!.toInt().toString();
     } else {
       label = value.toString();
     }

--- a/example/lib/widget.dart
+++ b/example/lib/widget.dart
@@ -3,17 +3,19 @@ import 'package:flutter/material.dart';
 typedef NavigateWidgetBuilder = Widget Function();
 
 mixin NavigateMixin on Widget {
-  NavigateWidgetBuilder get navigationBuilder;
+  NavigateWidgetBuilder? get navigationBuilder;
 
-  Future<T> navigate<T>(BuildContext context) {
-    if (navigationBuilder == null) return Future.value();
-
-    return Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => navigationBuilder(),
-      ),
-    );
+  Future<T?> navigate<T>(BuildContext context) {
+    if (navigationBuilder == null) {
+      return Future.value();
+    } else {
+      return Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => navigationBuilder!(),
+        ),
+      );
+    }
   }
 }
 
@@ -21,27 +23,27 @@ const kNavigationCardRadius = 8.0;
 
 class NavigationCard extends StatelessWidget with NavigateMixin {
   const NavigationCard({
-    Key key,
+    Key? key,
     this.margin,
     this.borderRadius =
         const BorderRadius.all(Radius.circular(kNavigationCardRadius)),
     this.navigationBuilder,
-    @required this.child,
+    required this.child,
   }) : super(key: key);
 
-  final EdgeInsetsGeometry margin;
-  final BorderRadius borderRadius;
+  final EdgeInsetsGeometry? margin;
+  final BorderRadius? borderRadius;
   final Widget child;
-  final NavigateWidgetBuilder navigationBuilder;
+  final NavigateWidgetBuilder? navigationBuilder;
 
   @override
   Widget build(BuildContext context) {
     return Card(
       clipBehavior: Clip.antiAliasWithSaveLayer,
       margin: margin,
-      shape: RoundedRectangleBorder(
-        borderRadius: borderRadius,
-      ),
+      shape: borderRadius != null
+          ? RoundedRectangleBorder(borderRadius: borderRadius!)
+          : null,
       child: InkWell(
         borderRadius: borderRadius,
         onTap: () => navigate(context),
@@ -54,7 +56,7 @@ class NavigationCard extends StatelessWidget with NavigateMixin {
 class TitleAppBar extends StatelessWidget with PreferredSizeWidget {
   TitleAppBar(
     this.title, {
-    Key key,
+    Key? key,
   })  : preferredSize = Size.fromHeight(kToolbarHeight),
         super(key: key);
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -14,9 +14,9 @@ dependencies:
     path: ../
 
 
-  font_awesome_flutter: ^8.10.0
-  url_launcher: ^5.7.10
-  url_launcher_web: ^0.1.5+1
+  font_awesome_flutter: ^9.0.0-nullsafety
+  url_launcher: ^6.0.2
+  url_launcher_web: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/connector_theme.dart
+++ b/lib/src/connector_theme.dart
@@ -38,25 +38,25 @@ class ConnectorThemeData with Diagnosticable {
 
   /// The color of [SolidLineConnector]s and connectors inside [TimelineNode]s,
   /// and so forth.
-  final Color color;
+  final Color? color;
 
   /// This represents the amount of horizontal or vertical space the connector
   /// takes up.
-  final double space;
+  final double? space;
 
   /// The thickness of the line drawn within the connector.
-  final double thickness;
+  final double? thickness;
 
   /// The amount of empty space at the edge of [SolidLineConnector].
-  final double indent;
+  final double? indent;
 
   /// Creates a copy of this object with the given fields replaced with the new
   /// values.
   ConnectorThemeData copyWith({
-    Color color,
-    double space,
-    double thickness,
-    double indent,
+    Color? color,
+    double? space,
+    double? thickness,
+    double? indent,
   }) {
     return ConnectorThemeData(
       color: color ?? this.color,
@@ -72,8 +72,7 @@ class ConnectorThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static ConnectorThemeData lerp(
-      ConnectorThemeData a, ConnectorThemeData b, double t) {
-    assert(t != null);
+      ConnectorThemeData? a, ConnectorThemeData? b, double t) {
     return ConnectorThemeData(
       color: Color.lerp(a?.color, b?.color, t),
       space: lerpDouble(a?.space, b?.space, t),
@@ -120,11 +119,10 @@ class ConnectorTheme extends InheritedTheme {
   /// Creates a connector theme that controls the configurations for
   /// [SolidLineConnector]s, connectors inside [TimelineNode]s.
   const ConnectorTheme({
-    Key key,
-    @required this.data,
-    Widget child,
-  })  : assert(data != null),
-        super(key: key, child: child);
+    Key? key,
+    required this.data,
+    required Widget child,
+  }) : super(key: key, child: child);
 
   /// The properties for descendant [SolidLineConnector]s, connectors inside
   /// [TimelineNode]s.
@@ -171,7 +169,7 @@ mixin ThemedConnectorComponent on Widget {
   /// {@template timelines.connector.direction}
   /// If this is null, then the [TimelineThemeData.direction] is used.
   /// {@endtemplate}
-  Axis get direction;
+  Axis? get direction;
   Axis getEffectiveDirection(BuildContext context) {
     return direction ?? TimelineTheme.of(context).direction;
   }
@@ -180,7 +178,7 @@ mixin ThemedConnectorComponent on Widget {
   /// If this is null, then the [ConnectorThemeData.thickness] is used which
   /// defaults to 2.0.
   /// {@endtemplate}
-  double get thickness;
+  double? get thickness;
   double getEffectiveThickness(BuildContext context) {
     return thickness ?? ConnectorTheme.of(context).thickness ?? 2.0;
   }
@@ -189,22 +187,22 @@ mixin ThemedConnectorComponent on Widget {
   /// If this is null, then the [ConnectorThemeData.space] is used. If that is
   /// also null, then this defaults to double.infinity.
   /// {@endtemplate}
-  double get space;
-  double getEffectiveSpace(BuildContext context) {
+  double? get space;
+  double? getEffectiveSpace(BuildContext context) {
     return space ?? ConnectorTheme.of(context).space;
   }
 
-  double get indent;
+  double? get indent;
   double getEffectiveIndent(BuildContext context) {
     return indent ?? ConnectorTheme.of(context).indent ?? 0.0;
   }
 
-  double get endIndent;
+  double? get endIndent;
   double getEffectiveEndIndent(BuildContext context) {
     return endIndent ?? ConnectorTheme.of(context).indent ?? 0.0;
   }
 
-  Color get color;
+  Color? get color;
   Color getEffectiveColor(BuildContext context) {
     return color ??
         ConnectorTheme.of(context).color ??

--- a/lib/src/connectors.dart
+++ b/lib/src/connectors.dart
@@ -17,7 +17,7 @@ import 'timeline_theme.dart';
 abstract class Connector extends StatelessWidget with ThemedConnectorComponent {
   /// Creates an connector.
   const Connector({
-    Key key,
+    Key? key,
     this.direction,
     this.space,
     this.thickness,
@@ -36,13 +36,13 @@ abstract class Connector extends StatelessWidget with ThemedConnectorComponent {
   ///
   /// * [SolidLineConnector],  exactly the same.
   factory Connector.solidLine({
-    Key key,
-    Axis direction,
-    double thickness,
-    double space,
-    double indent,
-    double endIndent,
-    Color color,
+    Key? key,
+    Axis? direction,
+    double? thickness,
+    double? space,
+    double? indent,
+    double? endIndent,
+    Color? color,
   }) {
     return SolidLineConnector(
       key: key,
@@ -61,16 +61,16 @@ abstract class Connector extends StatelessWidget with ThemedConnectorComponent {
   ///
   /// * [DashedLineConnector],  exactly the same.
   factory Connector.dashedLine({
-    Key key,
-    Axis direction,
-    double thickness,
-    double dash,
-    double gap,
-    double space,
-    double indent,
-    double endIndent,
-    Color color,
-    Color gapColor,
+    Key? key,
+    Axis? direction,
+    double? thickness,
+    double? dash,
+    double? gap,
+    double? space,
+    double? indent,
+    double? endIndent,
+    Color? color,
+    Color? gapColor,
   }) {
     return DashedLineConnector(
       key: key,
@@ -92,11 +92,11 @@ abstract class Connector extends StatelessWidget with ThemedConnectorComponent {
   ///
   /// * [TransparentConnector],  exactly the same.
   factory Connector.transparent({
-    Key key,
-    Axis direction,
-    double indent,
-    double endIndent,
-    double space,
+    Key? key,
+    Axis? direction,
+    double? indent,
+    double? endIndent,
+    double? space,
   }) {
     return TransparentConnector(
       key: key,
@@ -111,7 +111,7 @@ abstract class Connector extends StatelessWidget with ThemedConnectorComponent {
   ///
   /// {@macro timelines.connector.direction}
   @override
-  final Axis direction;
+  final Axis? direction;
 
   /// The connector's cross axis size extent.
   ///
@@ -119,34 +119,34 @@ abstract class Connector extends StatelessWidget with ThemedConnectorComponent {
   /// size specified by this value.
   /// {@macro timelines.connector.space}
   @override
-  final double space;
+  final double? space;
 
   /// The thickness of the line drawn within the connector.
   ///
   /// {@macro timelines.connector.thickness}
   @override
-  final double thickness;
+  final double? thickness;
 
   /// The amount of empty space to the leading edge of the connector.
   ///
   /// If this is null, then the [ConnectorThemeData.indent] is used. If that is
   /// also null, then this defaults to 0.0.
   @override
-  final double indent;
+  final double? indent;
 
   /// The amount of empty space to the trailing edge of the connector.
   ///
   /// If this is null, then the [ConnectorThemeData.indent] is used. If that is
   /// also null, then this defaults to 0.0.
   @override
-  final double endIndent;
+  final double? endIndent;
 
   /// The color to use when painting the line.
   ///
   /// If this is null, then the [ConnectorThemeData.color] is used. If that is
   /// also null, then [TimelineThemeData.color] is used.
   @override
-  final Color color;
+  final Color? color;
 }
 
 /// A thin line, with padding on either side.
@@ -161,13 +161,13 @@ class SolidLineConnector extends Connector {
   /// The [thickness], [space], [indent], and [endIndent] must be null or
   /// non-negative.
   const SolidLineConnector({
-    Key key,
-    Axis direction,
-    double thickness,
-    double space,
-    double indent,
-    double endIndent,
-    Color color,
+    Key? key,
+    Axis? direction,
+    double? thickness,
+    double? space,
+    double? indent,
+    double? endIndent,
+    Color? color,
   }) : super(
           key: key,
           thickness: thickness,
@@ -210,8 +210,6 @@ class SolidLineConnector extends Connector {
           ),
         );
     }
-
-    throw ArgumentError('invalid direction: $direction');
   }
 }
 
@@ -227,12 +225,12 @@ class DecoratedLineConnector extends Connector {
   /// The [thickness], [space], [indent], and [endIndent] must be null or
   /// non-negative.
   const DecoratedLineConnector({
-    Key key,
-    Axis direction,
-    double thickness,
-    double space,
-    double indent,
-    double endIndent,
+    Key? key,
+    Axis? direction,
+    double? thickness,
+    double? space,
+    double? indent,
+    double? endIndent,
     this.decoration,
   }) : super(
           key: key,
@@ -245,7 +243,7 @@ class DecoratedLineConnector extends Connector {
   /// The decoration to paint line.
   ///
   /// Use the [SolidLineConnector] class to specify a simple solid color line.
-  final Decoration decoration;
+  final Decoration? decoration;
 
   @override
   Widget build(BuildContext context) {
@@ -282,8 +280,6 @@ class DecoratedLineConnector extends Connector {
           ),
         );
     }
-
-    throw ArgumentError('invalid direction: $direction');
   }
 }
 
@@ -303,15 +299,15 @@ class DashedLineConnector extends Connector {
   /// The [thickness], [space], [indent], and [endIndent] must be null or
   /// non-negative.
   const DashedLineConnector({
-    Key key,
-    Axis direction,
-    double thickness,
+    Key? key,
+    Axis? direction,
+    double? thickness,
     this.dash,
     this.gap,
-    double space,
-    double indent,
-    double endIndent,
-    Color color,
+    double? space,
+    double? indent,
+    double? endIndent,
+    Color? color,
     this.gapColor,
   }) : super(
           key: key,
@@ -326,17 +322,17 @@ class DashedLineConnector extends Connector {
   /// The dash size of the line drawn within the connector.
   ///
   /// If this is null, then this defaults to 1.0.
-  final double dash;
+  final double? dash;
 
   /// The gap of the line drawn within the connector.
   ///
   /// If this is null, then this defaults to 1.0.
-  final double gap;
+  final double? gap;
 
   /// The color to use when painting the gap in the line.
   ///
   /// If this is null, then the [Colors.transparent] is used.
-  final Color gapColor;
+  final Color? gapColor;
 
   @override
   Widget build(BuildContext context) {
@@ -369,11 +365,11 @@ class TransparentConnector extends Connector {
   ///
   /// The [space], [indent], and [endIndent] must be null or non-negative.
   const TransparentConnector({
-    Key key,
-    Axis direction,
-    double indent,
-    double endIndent,
-    double space,
+    Key? key,
+    Axis? direction,
+    double? indent,
+    double? endIndent,
+    double? space,
   }) : super(
           key: key,
           direction: direction,
@@ -401,17 +397,15 @@ class _ConnectorIndent extends StatelessWidget {
   /// The [direction]and [child] must be null. And [space], [indent] and
   /// [endIndent] must be null or non-negative.
   const _ConnectorIndent({
-    Key key,
-    @required this.direction,
-    @required this.space,
-    @required this.indent,
-    @required this.endIndent,
-    @required this.child,
-  })  : assert(direction != null),
-        assert(space == null || space >= 0),
+    Key? key,
+    required this.direction,
+    required this.space,
+    this.indent,
+    this.endIndent,
+    required this.child,
+  })   : assert(space == null || space >= 0),
         assert(indent == null || indent >= 0),
         assert(endIndent == null || endIndent >= 0),
-        assert(child != null),
         super(key: key);
 
   /// {@macro timelines.direction}
@@ -421,13 +415,13 @@ class _ConnectorIndent extends StatelessWidget {
   ///
   /// The connector itself is always drawn as a line that is centered within the
   /// size specified by this value.
-  final double space;
+  final double? space;
 
   /// The amount of empty space to the leading edge of the connector.
-  final double indent;
+  final double? indent;
 
   /// The amount of empty space to the trailing edge of the connector.
-  final double endIndent;
+  final double? endIndent;
 
   /// The widget below this widget in the tree.
   ///
@@ -443,12 +437,12 @@ class _ConnectorIndent extends StatelessWidget {
         child: Padding(
           padding: direction == Axis.vertical
               ? EdgeInsetsDirectional.only(
-                  top: indent,
-                  bottom: endIndent,
+                  top: indent ?? 0,
+                  bottom: endIndent ?? 0,
                 )
               : EdgeInsetsDirectional.only(
-                  start: indent,
-                  end: endIndent,
+                  start: indent ?? 0,
+                  end: endIndent ?? 0,
                 ),
           child: child,
         ),

--- a/lib/src/indicator_theme.dart
+++ b/lib/src/indicator_theme.dart
@@ -37,23 +37,23 @@ class IndicatorThemeData with Diagnosticable {
 
   /// The color of [DotIndicator]s and indicators inside [TimelineNode]s, and so
   /// forth.
-  final Color color;
+  final Color? color;
 
   /// The size of [DotIndicator]s and indicators inside [TimelineNode]s, and so
   /// forth in logical pixels.
   ///
   /// Indicators occupy a square with width and height equal to size.
-  final double size;
+  final double? size;
 
   /// A position of indicator inside both two connectors.
-  final double position;
+  final double? position;
 
   /// Creates a copy of this object with the given fields replaced with the new
   /// values.
   IndicatorThemeData copyWith({
-    Color color,
-    double size,
-    double position,
+    Color? color,
+    double? size,
+    double? position,
   }) {
     return IndicatorThemeData(
       color: color ?? this.color,
@@ -68,8 +68,7 @@ class IndicatorThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static IndicatorThemeData lerp(
-      IndicatorThemeData a, IndicatorThemeData b, double t) {
-    assert(t != null);
+      IndicatorThemeData? a, IndicatorThemeData? b, double t) {
     return IndicatorThemeData(
       color: Color.lerp(a?.color, b?.color, t),
       size: lerpDouble(a?.size, b?.size, t),
@@ -108,11 +107,10 @@ class IndicatorTheme extends InheritedTheme {
   /// Creates an indicator theme that controls the color and size for
   /// [DotIndicator]s, indicators inside [TimelineNode]s.
   const IndicatorTheme({
-    Key key,
-    @required this.data,
-    Widget child,
-  })  : assert(data != null),
-        super(key: key, child: child);
+    Key? key,
+    required this.data,
+    required Widget child,
+  }) : super(key: key, child: child);
 
   /// The properties for descendant [DotIndicator]s, indicators inside
   /// [TimelineNode]s.
@@ -161,7 +159,7 @@ mixin ThemedIndicatorComponent on PositionedIndicator {
   /// If no [IndicatorTheme] and no [TimelineTheme] is specified, indicators
   /// will default to blue.
   /// {@endtemplate}
-  Color get color;
+  Color? get color;
   Color getEffectiveColor(BuildContext context) {
     return color ??
         IndicatorTheme.of(context).color ??
@@ -175,8 +173,8 @@ mixin ThemedIndicatorComponent on PositionedIndicator {
   /// [IndicatorTheme], or it does not specify an explicit size, then it
   /// defaults to own child size(0.0).
   /// {@endtemplate}
-  double get size;
-  double getEffectiveSize(BuildContext context) {
+  double? get size;
+  double? getEffectiveSize(BuildContext context) {
     return size ?? IndicatorTheme.of(context).size;
   }
 }

--- a/lib/src/indicators.dart
+++ b/lib/src/indicators.dart
@@ -9,7 +9,7 @@ mixin PositionedIndicator on Widget {
   /// If this is null, then the [IndicatorThemeData.position] is used. If that
   /// is also null, then this defaults to [TimelineThemeData.indicatorPosition].
   /// {@endtemplate}
-  double get position;
+  double? get position;
   double getEffectivePosition(BuildContext context) {
     return position ??
         IndicatorTheme.of(context).position ??
@@ -28,7 +28,7 @@ abstract class Indicator extends StatelessWidget
     with PositionedIndicator, ThemedIndicatorComponent {
   /// Creates an indicator.
   const Indicator({
-    Key key,
+    Key? key,
     this.size,
     this.color,
     this.border,
@@ -44,12 +44,12 @@ abstract class Indicator extends StatelessWidget
   ///
   /// * [DotIndicator],  exactly the same.
   factory Indicator.dot({
-    Key key,
-    double size,
-    Color color,
-    double position,
-    Border border,
-    Widget child,
+    Key? key,
+    double? size,
+    Color? color,
+    double? position,
+    Border? border,
+    Widget? child,
   }) =>
       DotIndicator(
         size: size,
@@ -65,13 +65,13 @@ abstract class Indicator extends StatelessWidget
   ///
   /// * [OutlinedDotIndicator], exactly the same.
   factory Indicator.outlined({
-    Key key,
-    double size,
-    Color color,
-    Color backgroundColor,
-    double position,
+    Key? key,
+    double? size,
+    Color? color,
+    Color? backgroundColor,
+    double? position,
     double borderWidth = 2.0,
-    Widget child,
+    Widget? child,
   }) =>
       OutlinedDotIndicator(
         size: size,
@@ -88,9 +88,9 @@ abstract class Indicator extends StatelessWidget
   ///
   /// * [ContainerIndicator], this is created without child.
   factory Indicator.transparent({
-    Key key,
-    double size,
-    double position,
+    Key? key,
+    double? size,
+    double? position,
   }) =>
       ContainerIndicator(
         size: size,
@@ -103,10 +103,10 @@ abstract class Indicator extends StatelessWidget
   ///
   /// * [OutlinedDotIndicator], exactly the same.
   factory Indicator.widget({
-    Key key,
-    double size,
-    double position,
-    Widget child,
+    Key? key,
+    double? size,
+    double? position,
+    Widget? child,
   }) =>
       ContainerIndicator(
         size: size,
@@ -118,27 +118,27 @@ abstract class Indicator extends StatelessWidget
   ///
   /// {@macro timelines.indicator.size}
   @override
-  final double size;
+  final double? size;
 
   /// The color to use when drawing the dot.
   ///
   /// {@macro timelines.indicator.color}
   @override
-  final Color color;
+  final Color? color;
 
   /// The position of a indicator between the two connectors.
   ///
   /// {@macro timelines.indicator.position}
   @override
-  final double position;
+  final double? position;
 
   /// The border to use when drawing the dot's outline.
-  final BoxBorder border;
+  final BoxBorder? border;
 
   /// The widget below this widget in the tree.
   ///
   /// {@macro flutter.widgets.child}
-  final Widget child;
+  final Widget? child;
 }
 
 /// A widget that displays an [child]. The [child] if null, the indicator is not
@@ -146,9 +146,9 @@ abstract class Indicator extends StatelessWidget
 class ContainerIndicator extends Indicator {
   /// Creates a container indicator.
   const ContainerIndicator({
-    Key key,
-    double size,
-    double position,
+    Key? key,
+    double? size,
+    double? position,
     this.child,
   }) : super(
           key: key,
@@ -160,7 +160,7 @@ class ContainerIndicator extends Indicator {
   /// The widget below this widget in the tree.
   ///
   /// {@macro flutter.widgets.child}
-  final Widget child;
+  final Widget? child;
 
   @override
   Widget build(BuildContext context) {
@@ -179,10 +179,10 @@ class DotIndicator extends Indicator {
   ///
   /// The [size] must be null or non-negative.
   const DotIndicator({
-    Key key,
-    double size,
-    Color color,
-    double position,
+    Key? key,
+    double? size,
+    Color? color,
+    double? position,
     this.border,
     this.child,
   }) : super(
@@ -193,12 +193,12 @@ class DotIndicator extends Indicator {
         );
 
   /// The border to use when drawing the dot's outline.
-  final BoxBorder border;
+  final BoxBorder? border;
 
   /// The widget below this widget in the tree.
   ///
   /// {@macro flutter.widgets.child}
-  final Widget child;
+  final Widget? child;
 
   @override
   Widget build(BuildContext context) {
@@ -225,10 +225,10 @@ class OutlinedDotIndicator extends Indicator {
   ///
   /// The [size] must be null or non-negative.
   const OutlinedDotIndicator({
-    Key key,
-    double size,
-    Color color,
-    double position,
+    Key? key,
+    double? size,
+    Color? color,
+    double? position,
     this.backgroundColor,
     this.borderWidth = 2.0,
     this.child,
@@ -244,7 +244,7 @@ class OutlinedDotIndicator extends Indicator {
   /// The color to use when drawing the dot in outline.
   ///
   /// {@macro timelines.indicator.color}
-  final Color backgroundColor;
+  final Color? backgroundColor;
 
   /// The width of this outline, in logical pixels.
   final double borderWidth;
@@ -252,7 +252,7 @@ class OutlinedDotIndicator extends Indicator {
   /// The widget below this widget in the tree.
   ///
   /// {@macro flutter.widgets.child}
-  final Widget child;
+  final Widget? child;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/line_painter.dart
+++ b/lib/src/line_painter.dart
@@ -28,20 +28,16 @@ class DashedLinePainter extends CustomPainter {
   /// The [direction], [color], [gapColor] and [strokeCap] arguments must not be
   /// null.
   const DashedLinePainter({
-    @required this.direction,
-    @required this.color,
+    required this.direction,
+    required this.color,
     this.gapColor = Colors.transparent,
     this.dashSize = 1.0,
     this.gapSize = 1.0,
     this.strokeWidth = 1.0,
     this.strokeCap = StrokeCap.square,
-  })  : assert(direction != null),
-        assert(color != null),
-        assert(gapColor != null),
-        assert(dashSize >= 1),
+  })  : assert(dashSize >= 1),
         assert(gapSize >= 0),
-        assert(strokeWidth >= 0),
-        assert(strokeCap != null);
+        assert(strokeWidth >= 0);
 
   /// {@macro timelines.direction}
   final Axis direction;
@@ -116,11 +112,11 @@ class DashedLinePainter extends CustomPainter {
 
 class _DashOffset extends Offset {
   factory _DashOffset({
-    @required Size containerSize,
-    @required double strokeWidth,
-    @required double dashSize,
-    @required double gapSize,
-    @required Axis axis,
+    required Size containerSize,
+    required double strokeWidth,
+    required double dashSize,
+    required double gapSize,
+    required Axis axis,
   }) {
     return _DashOffset._(
       dx: axis == Axis.vertical ? containerSize.width / 2 : 0,
@@ -134,13 +130,13 @@ class _DashOffset extends Offset {
   }
 
   const _DashOffset._({
-    @required double dx,
-    @required double dy,
-    @required this.strokeWidth,
-    @required this.containerSize,
-    @required this.dashSize,
-    @required this.gapSize,
-    @required this.axis,
+    required double dx,
+    required double dy,
+    required this.strokeWidth,
+    required this.containerSize,
+    required this.dashSize,
+    required this.gapSize,
+    required this.axis,
   }) : super(dx, dy);
 
   final Size containerSize;
@@ -175,9 +171,9 @@ class _DashOffset extends Offset {
 
   _DashOffset _translateDirectionally(double offset) {
     if (axis == Axis.vertical) {
-      return translate(0, offset);
+      return translate(0, offset) as _DashOffset;
     } else {
-      return translate(offset, 0);
+      return translate(offset, 0) as _DashOffset;
     }
   }
 
@@ -198,13 +194,13 @@ class _DashOffset extends Offset {
   }
 
   _DashOffset copyWith({
-    double dx,
-    double dy,
-    Size containerSize,
-    double strokeWidth,
-    double dashSize,
-    double gapSize,
-    Axis axis,
+    double? dx,
+    double? dy,
+    Size? containerSize,
+    double? strokeWidth,
+    double? dashSize,
+    double? gapSize,
+    Axis? axis,
   }) {
     return _DashOffset._(
       dx: dx ?? this.dx,

--- a/lib/src/timeline_node.dart
+++ b/lib/src/timeline_node.dart
@@ -11,7 +11,7 @@ mixin TimelineTileNode on Widget {
   /// {@template timelines.node.position}
   /// If this is null, then the [TimelineThemeData.nodePosition] is used.
   /// {@endtemplate}
-  double get position;
+  double? get position;
   double getEffectivePosition(BuildContext context) {
     return position ?? TimelineTheme.of(context).nodePosition;
   }
@@ -25,7 +25,7 @@ class TimelineNode extends StatelessWidget with TimelineTileNode {
   ///
   /// The [indicatorPosition] must be null or a value between 0 and 1.
   const TimelineNode({
-    Key key,
+    Key? key,
     this.direction,
     this.startConnector,
     this.endConnector,
@@ -33,26 +33,25 @@ class TimelineNode extends StatelessWidget with TimelineTileNode {
     this.indicatorPosition,
     this.position,
     this.overlap,
-  })  : assert(indicator != null),
-        assert(indicatorPosition == null ||
+  })  : assert(indicatorPosition == null ||
             0 <= indicatorPosition && indicatorPosition <= 1),
         super(key: key);
 
   /// Creates a timeline node that connects the dot indicator in a solid line.
   TimelineNode.simple({
-    Key key,
-    Axis direction,
-    Color color,
-    double lineThickness,
-    double nodePosition,
-    double indicatorPosition,
-    double indicatorSize,
-    Widget indicatorChild,
-    double indent,
-    double endIndent,
+    Key? key,
+    Axis? direction,
+    Color? color,
+    double? lineThickness,
+    double? nodePosition,
+    double? indicatorPosition,
+    double? indicatorSize,
+    Widget? indicatorChild,
+    double? indent,
+    double? endIndent,
     bool drawStartConnector = true,
     bool drawEndConnector = true,
-    bool overlap,
+    bool? overlap,
   }) : this(
           key: key,
           direction: direction,
@@ -86,13 +85,13 @@ class TimelineNode extends StatelessWidget with TimelineTileNode {
         );
 
   /// {@macro timelines.direction}
-  final Axis direction;
+  final Axis? direction;
 
   /// The connector of the start edge of this node
-  final Widget startConnector;
+  final Widget? startConnector;
 
   /// The connector of the end edge of this node
-  final Widget endConnector;
+  final Widget? endConnector;
 
   /// The indicator of the node
   final Widget indicator;
@@ -100,19 +99,19 @@ class TimelineNode extends StatelessWidget with TimelineTileNode {
   /// The position of a indicator between the two connectors.
   ///
   /// {@macro timelines.indicator.position}
-  final double indicatorPosition;
+  final double? indicatorPosition;
 
   /// A position of timeline node between both two contents.
   ///
   /// {@macro timelines.node.position}
   @override
-  final double position;
+  final double? position;
 
   /// Determine whether each connectors and indicator will overlap.
   ///
   /// When each connectors overlap, they are drawn from the center offset of the
   /// indicator.
-  final bool overlap;
+  final bool? overlap;
 
   double _getEffectiveIndicatorPosition(BuildContext context) {
     var indicatorPosition = this.indicatorPosition;

--- a/lib/src/timeline_theme.dart
+++ b/lib/src/timeline_theme.dart
@@ -25,9 +25,9 @@ class TimelineTheme extends StatelessWidget {
   ///
   /// The [data] and [child] arguments must not be null.
   const TimelineTheme({
-    Key key,
-    @required this.data,
-    @required this.child,
+    Key? key,
+    required this.data,
+    required this.child,
   }) : super(key: key);
 
   /// Specifies the direction for descendant widgets.
@@ -76,7 +76,7 @@ class TimelineTheme extends StatelessWidget {
   static TimelineThemeData of(BuildContext context) {
     final inheritedTheme =
         context.dependOnInheritedWidgetOfExactType<_InheritedTheme>();
-    return inheritedTheme?.theme?.data ?? _kFallbackTheme;
+    return inheritedTheme?.theme.data ?? _kFallbackTheme;
   }
 
   @override
@@ -100,11 +100,10 @@ class TimelineTheme extends StatelessWidget {
 
 class _InheritedTheme extends InheritedTheme {
   const _InheritedTheme({
-    Key key,
-    @required this.theme,
-    @required Widget child,
-  })  : assert(theme != null),
-        super(key: key, child: child);
+    Key? key,
+    required this.theme,
+    required Widget child,
+  }) : super(key: key, child: child);
 
   final TimelineTheme theme;
 
@@ -179,13 +178,13 @@ class TimelineThemeData with Diagnosticable {
   ///  * [TimelineThemeData.horizontal], which creates a horizontal direction
   ///  TimelineThemeData.
   factory TimelineThemeData({
-    Axis direction,
-    Color color,
-    double nodePosition,
-    bool nodeItemOverlap,
-    double indicatorPosition,
-    IndicatorThemeData indicatorTheme,
-    ConnectorThemeData connectorTheme,
+    Axis? direction,
+    Color? color,
+    double? nodePosition,
+    bool? nodeItemOverlap,
+    double? indicatorPosition,
+    IndicatorThemeData? indicatorTheme,
+    ConnectorThemeData? connectorTheme,
   }) {
     direction ??= Axis.vertical;
     color ??= Colors
@@ -218,19 +217,14 @@ class TimelineThemeData with Diagnosticable {
   /// intermediate themes based on two themes created with the
   /// [new TimelineThemeData] constructor.
   const TimelineThemeData.raw({
-    @required this.direction,
-    @required this.color,
-    @required this.nodePosition,
-    @required this.nodeItemOverlap,
-    @required this.indicatorPosition,
-    @required this.indicatorTheme,
-    @required this.connectorTheme,
-  })  : assert(direction != null),
-        assert(color != null),
-        assert(nodePosition != null),
-        assert(indicatorPosition != null),
-        assert(indicatorTheme != null),
-        assert(connectorTheme != null);
+    required this.direction,
+    required this.color,
+    required this.nodePosition,
+    required this.nodeItemOverlap,
+    required this.indicatorPosition,
+    required this.indicatorTheme,
+    required this.connectorTheme,
+  });
 
   /// A default vertical theme.
   factory TimelineThemeData.vertical() => TimelineThemeData(
@@ -276,13 +270,13 @@ class TimelineThemeData with Diagnosticable {
   /// Creates a copy of this theme but with the given fields replaced with the
   /// new values.
   TimelineThemeData copyWith({
-    Axis direction,
-    Color color,
-    double nodePosition,
-    bool nodeItemOverlap,
-    double indicatorPosition,
-    IndicatorThemeData indicatorTheme,
-    ConnectorThemeData connectorTheme,
+    Axis? direction,
+    Color? color,
+    double? nodePosition,
+    bool? nodeItemOverlap,
+    double? indicatorPosition,
+    IndicatorThemeData? indicatorTheme,
+    ConnectorThemeData? connectorTheme,
   }) {
     return TimelineThemeData.raw(
       direction: direction ?? this.direction,
@@ -302,19 +296,16 @@ class TimelineThemeData with Diagnosticable {
   /// {@macro dart.ui.shadow.lerp}
   static TimelineThemeData lerp(
       TimelineThemeData a, TimelineThemeData b, double t) {
-    assert(a != null);
-    assert(b != null);
-    assert(t != null);
     // Warning: make sure these properties are in the exact same order as in
     // hashValues() and in the raw constructor and in the order of fields in
     // the class and in the lerp() method.
     return TimelineThemeData.raw(
       direction: t < 0.5 ? a.direction : b.direction,
-      color: Color.lerp(a.color, b.color, t),
-      nodePosition: lerpDouble(a.nodePosition, b.nodePosition, t),
+      color: Color.lerp(a.color, b.color, t)!,
+      nodePosition: lerpDouble(a.nodePosition, b.nodePosition, t)!,
       nodeItemOverlap: t < 0.5 ? a.nodeItemOverlap : b.nodeItemOverlap,
       indicatorPosition:
-          lerpDouble(a.indicatorPosition, b.indicatorPosition, t),
+          lerpDouble(a.indicatorPosition, b.indicatorPosition, t)!,
       indicatorTheme:
           IndicatorThemeData.lerp(a.indicatorTheme, b.indicatorTheme, t),
       connectorTheme:

--- a/lib/src/timeline_tile.dart
+++ b/lib/src/timeline_tile.dart
@@ -26,18 +26,16 @@ enum TimelineNodeAlign {
 /// The [node] is displayed between the two.
 class TimelineTile extends StatelessWidget {
   const TimelineTile({
-    Key key,
+    Key? key,
     this.direction,
-    @required this.node,
+    required this.node,
     this.nodeAlign = TimelineNodeAlign.basic,
     this.nodePosition,
     this.contents,
     this.oppositeContents,
     this.mainAxisExtent,
     this.crossAxisExtent,
-  })  : assert(node != null),
-        assert(nodeAlign != null),
-        assert(
+  })  : assert(
           nodeAlign == TimelineNodeAlign.basic ||
               (nodeAlign != TimelineNodeAlign.basic && nodePosition == null),
           'Cannot provide both a nodeAlign and a nodePosition',
@@ -48,7 +46,7 @@ class TimelineTile extends StatelessWidget {
   /// {@template timelines.direction}
   /// The axis along which the timeline scrolls.
   /// {@endtemplate}
-  final Axis direction;
+  final Axis? direction;
 
   /// A widget that displays indicator and two connectors.
   final Widget node;
@@ -67,13 +65,13 @@ class TimelineTile extends StatelessWidget {
   /// A position of [node] inside both two contents.
   ///
   /// {@macro timelines.node.position}
-  final double nodePosition;
+  final double? nodePosition;
 
   /// The contents to display inside the timeline tile.
-  final Widget contents;
+  final Widget? contents;
 
   /// The contents to display on the opposite side of the [contents].
-  final Widget oppositeContents;
+  final Widget? oppositeContents;
 
   /// The extent of the child in the scrolling axis.
   /// If the scroll axis is vertical, this extent is the child's height. If the
@@ -85,13 +83,13 @@ class TimelineTile extends StatelessWidget {
   /// Specifying an [mainAxisExtent] is more efficient than letting the tile
   /// determine their own extent because the because it don't use the Intrinsic
   /// widget([IntrinsicHeight]/[IntrinsicWidth]) when building.
-  final double mainAxisExtent;
+  final double? mainAxisExtent;
 
   /// The extent of the child in the non-scrolling axis.
   ///
   /// If the scroll axis is vertical, this extent is the child's width. If the
   /// scroll axis is horizontal, this extent is the child's height.
-  final double crossAxisExtent;
+  final double? crossAxisExtent;
 
   double _getEffectiveNodePosition(BuildContext context) {
     if (nodeAlign == TimelineNodeAlign.start) return 0.0;

--- a/lib/src/timeline_tile_builder.dart
+++ b/lib/src/timeline_tile_builder.dart
@@ -185,24 +185,23 @@ class TimelineTileBuilder {
   ///  * [TimelineTileBuilder.connectedFromStyle], which builds connected tiles
   ///  from style.
   factory TimelineTileBuilder.connected({
-    @required int itemCount,
+    required int itemCount,
     ContentsAlign contentsAlign = ContentsAlign.basic,
     ConnectionDirection connectionDirection = ConnectionDirection.after,
-    IndexedWidgetBuilder contentsBuilder,
-    IndexedWidgetBuilder oppositeContentsBuilder,
-    IndexedWidgetBuilder indicatorBuilder,
-    ConnectedConnectorBuilder connectorBuilder,
-    WidgetBuilder firstConnectorBuilder,
-    WidgetBuilder lastConnectorBuilder,
-    double itemExtent,
-    IndexedValueBuilder<double> itemExtentBuilder,
-    IndexedValueBuilder<double> nodePositionBuilder,
-    IndexedValueBuilder<double> indicatorPositionBuilder,
+    IndexedWidgetBuilder? contentsBuilder,
+    IndexedWidgetBuilder? oppositeContentsBuilder,
+    IndexedWidgetBuilder? indicatorBuilder,
+    ConnectedConnectorBuilder? connectorBuilder,
+    WidgetBuilder? firstConnectorBuilder,
+    WidgetBuilder? lastConnectorBuilder,
+    double? itemExtent,
+    IndexedValueBuilder<double>? itemExtentBuilder,
+    IndexedValueBuilder<double>? nodePositionBuilder,
+    IndexedValueBuilder<double>? indicatorPositionBuilder,
     bool addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     bool addSemanticIndexes = true,
   }) {
-    assert(connectionDirection != null);
     return TimelineTileBuilder(
       itemCount: itemCount,
       contentsAlign: contentsAlign,
@@ -236,22 +235,20 @@ class TimelineTileBuilder {
   ///  * [TimelineTileBuilder.connected], which builds connected tiles.
   ///  * [TimelineTileBuilder.fromStyle], which builds tiles from style.
   factory TimelineTileBuilder.connectedFromStyle({
-    @required @required int itemCount,
+    @required required int itemCount,
     ConnectionDirection connectionDirection = ConnectionDirection.after,
-    IndexedWidgetBuilder contentsBuilder,
-    IndexedWidgetBuilder oppositeContentsBuilder,
+    IndexedWidgetBuilder? contentsBuilder,
+    IndexedWidgetBuilder? oppositeContentsBuilder,
     ContentsAlign contentsAlign = ContentsAlign.basic,
-    IndexedValueBuilder<IndicatorStyle> indicatorStyleBuilder,
-    IndexedValueBuilder<ConnectorStyle> connectorStyleBuilder,
+    IndexedValueBuilder<IndicatorStyle>? indicatorStyleBuilder,
+    IndexedValueBuilder<ConnectorStyle>? connectorStyleBuilder,
     ConnectorStyle firstConnectorStyle = ConnectorStyle.solidLine,
     ConnectorStyle lastConnectorStyle = ConnectorStyle.solidLine,
-    double itemExtent,
-    IndexedValueBuilder<double> itemExtentBuilder,
-    IndexedValueBuilder<double> nodePositionBuilder,
-    IndexedValueBuilder<double> indicatorPositionBuilder,
+    double? itemExtent,
+    IndexedValueBuilder<double>? itemExtentBuilder,
+    IndexedValueBuilder<double>? nodePositionBuilder,
+    IndexedValueBuilder<double>? indicatorPositionBuilder,
   }) {
-    assert(connectionDirection != null);
-
     return TimelineTileBuilder(
       itemCount: itemCount,
       contentsAlign: contentsAlign,
@@ -292,17 +289,17 @@ class TimelineTileBuilder {
   ///  * [ConnectorStyle]
   ///  * [ContentsAlign]
   factory TimelineTileBuilder.fromStyle({
-    @required int itemCount,
-    IndexedWidgetBuilder contentsBuilder,
-    IndexedWidgetBuilder oppositeContentsBuilder,
+    required int itemCount,
+    IndexedWidgetBuilder? contentsBuilder,
+    IndexedWidgetBuilder? oppositeContentsBuilder,
     ContentsAlign contentsAlign = ContentsAlign.basic,
     IndicatorStyle indicatorStyle = IndicatorStyle.dot,
     ConnectorStyle connectorStyle = ConnectorStyle.solidLine,
     ConnectorStyle endConnectorStyle = ConnectorStyle.solidLine,
-    double itemExtent,
-    IndexedValueBuilder<double> itemExtentBuilder,
-    IndexedValueBuilder<double> nodePositionBuilder,
-    IndexedValueBuilder<double> indicatorPositionBuilder,
+    double? itemExtent,
+    IndexedValueBuilder<double>? itemExtentBuilder,
+    IndexedValueBuilder<double>? nodePositionBuilder,
+    IndexedValueBuilder<double>? indicatorPositionBuilder,
     bool addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     bool addSemanticIndexes = true,
@@ -334,19 +331,19 @@ class TimelineTileBuilder {
   ///
   /// TODO: need refactoring, is it has many builders...?
   factory TimelineTileBuilder({
-    @required int itemCount,
+    required int itemCount,
     ContentsAlign contentsAlign = ContentsAlign.basic,
-    IndexedWidgetBuilder contentsBuilder,
-    IndexedWidgetBuilder oppositeContentsBuilder,
-    IndexedWidgetBuilder indicatorBuilder,
-    IndexedWidgetBuilder startConnectorBuilder,
-    IndexedWidgetBuilder endConnectorBuilder,
-    double itemExtent,
-    IndexedValueBuilder<double> itemExtentBuilder,
-    IndexedValueBuilder<double> nodePositionBuilder,
-    IndexedValueBuilder<bool> nodeItemOverlapBuilder,
-    IndexedValueBuilder<double> indicatorPositionBuilder,
-    IndexedValueBuilder<TimelineThemeData> themeBuilder,
+    IndexedWidgetBuilder? contentsBuilder,
+    IndexedWidgetBuilder? oppositeContentsBuilder,
+    IndexedWidgetBuilder? indicatorBuilder,
+    IndexedWidgetBuilder? startConnectorBuilder,
+    IndexedWidgetBuilder? endConnectorBuilder,
+    double? itemExtent,
+    IndexedValueBuilder<double>? itemExtentBuilder,
+    IndexedValueBuilder<double>? nodePositionBuilder,
+    IndexedValueBuilder<bool>? nodeItemOverlapBuilder,
+    IndexedValueBuilder<double>? indicatorPositionBuilder,
+    IndexedValueBuilder<TimelineThemeData>? themeBuilder,
   }) {
     assert(
       itemExtent == null || itemExtentBuilder == null,
@@ -397,86 +394,90 @@ class TimelineTileBuilder {
 
   const TimelineTileBuilder._(
     this._builder, {
-    @required this.itemCount,
-  })  : assert(_builder != null),
-        assert(itemCount != null && itemCount >= 0);
+    required this.itemCount,
+  }) : assert(itemCount >= 0);
 
   final IndexedWidgetBuilder _builder;
   final int itemCount;
 
-  Widget build(BuildContext context, index) {
+  Widget build(BuildContext context, int index) {
     return _builder(context, index);
   }
 
   static IndexedWidgetBuilder _createConnectedStartConnectorBuilder({
-    @required ConnectionDirection connectionDirection,
-    @required WidgetBuilder firstConnectorBuilder,
-    @required ConnectedConnectorBuilder connectorBuilder,
+    ConnectionDirection? connectionDirection,
+    WidgetBuilder? firstConnectorBuilder,
+    ConnectedConnectorBuilder? connectorBuilder,
   }) =>
       (context, index) {
         if (index == 0) {
           if (firstConnectorBuilder != null) {
-            return firstConnectorBuilder?.call(context);
+            return firstConnectorBuilder.call(context);
           } else {
-            return null;
+            return SizedBox();
           }
         }
 
         if (connectionDirection == ConnectionDirection.before) {
-          return connectorBuilder?.call(context, index, ConnectorType.start);
+          return connectorBuilder?.call(context, index, ConnectorType.start) ??
+              const SizedBox();
         } else {
           return connectorBuilder?.call(
-              context, index - 1, ConnectorType.start);
+                  context, index - 1, ConnectorType.start) ??
+              const SizedBox();
         }
       };
 
   static IndexedWidgetBuilder _createConnectedEndConnectorBuilder({
-    @required ConnectionDirection connectionDirection,
-    @required WidgetBuilder lastConnectorBuilder,
-    @required ConnectedConnectorBuilder connectorBuilder,
-    @required int itemCount,
+    ConnectionDirection? connectionDirection,
+    WidgetBuilder? lastConnectorBuilder,
+    ConnectedConnectorBuilder? connectorBuilder,
+    required int itemCount,
   }) =>
       (context, index) {
-        if (itemCount != null && index == itemCount - 1) {
+        if (index == itemCount - 1) {
           if (lastConnectorBuilder != null) {
-            return lastConnectorBuilder?.call(context);
+            return lastConnectorBuilder.call(context);
           } else {
-            return null;
+            return const SizedBox();
           }
         }
 
         if (connectionDirection == ConnectionDirection.before) {
-          return connectorBuilder?.call(context, index + 1, ConnectorType.end);
+          return connectorBuilder?.call(
+                  context, index + 1, ConnectorType.end) ??
+              const SizedBox();
         } else {
-          return connectorBuilder?.call(context, index, ConnectorType.end);
+          return connectorBuilder?.call(context, index, ConnectorType.end) ??
+              const SizedBox();
         }
       };
 
   static IndexedWidgetBuilder _createAlignedContentsBuilder({
-    @required ContentsAlign align,
-    IndexedWidgetBuilder contentsBuilder,
-    IndexedWidgetBuilder oppositeContentsBuilder,
+    required ContentsAlign align,
+    IndexedWidgetBuilder? contentsBuilder,
+    IndexedWidgetBuilder? oppositeContentsBuilder,
   }) {
-    assert(align != null);
-
     return (context, index) {
       switch (align) {
         case ContentsAlign.alternating:
           if (index.isOdd) {
-            return oppositeContentsBuilder?.call(context, index);
+            return oppositeContentsBuilder?.call(context, index) ??
+                const SizedBox();
           }
 
-          return contentsBuilder?.call(context, index);
+          return contentsBuilder?.call(context, index) ?? const SizedBox();
         case ContentsAlign.reverse:
-          return oppositeContentsBuilder?.call(context, index);
+          return oppositeContentsBuilder?.call(context, index) ??
+              const SizedBox();
         case ContentsAlign.basic:
         default:
-          return contentsBuilder?.call(context, index);
+          return contentsBuilder?.call(context, index) ?? const SizedBox();
       }
     };
   }
 
-  static WidgetBuilder _createStyledIndicatorBuilder(IndicatorStyle style) {
+  static WidgetBuilder _createStyledIndicatorBuilder(IndicatorStyle? style) {
     return (_) {
       switch (style) {
         case IndicatorStyle.dot:
@@ -492,7 +493,7 @@ class TimelineTileBuilder {
     };
   }
 
-  static WidgetBuilder _createStyledConnectorBuilder(ConnectorStyle style) {
+  static WidgetBuilder _createStyledConnectorBuilder(ConnectorStyle? style) {
     return (_) {
       switch (style) {
         case ConnectorStyle.solidLine:
@@ -534,8 +535,8 @@ int _kDefaultSemanticIndexCallback(Widget _, int localIndex) => localIndex;
 class TimelineTileBuilderDelegate extends SliverChildBuilderDelegate {
   TimelineTileBuilderDelegate(
     IndexedWidgetBuilder builder, {
-    ChildIndexGetter findChildIndexCallback,
-    int childCount,
+    ChildIndexGetter? findChildIndexCallback,
+    int? childCount,
     bool addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     bool addSemanticIndexes = true,

--- a/lib/src/timeline_tile_builder.dart
+++ b/lib/src/timeline_tile_builder.dart
@@ -110,7 +110,7 @@ enum ConnectorStyle {
 
 /// Signature for a function that creates a connected connector widget for a
 /// given index and type, e.g., in a timeline tile builder.
-typedef ConnectedConnectorBuilder = Widget Function(
+typedef ConnectedConnectorBuilder = Widget? Function(
     BuildContext context, int index, ConnectorType type);
 
 /// Signature for a function that creates a typed value for a given index, e.g.,
@@ -188,9 +188,9 @@ class TimelineTileBuilder {
     required int itemCount,
     ContentsAlign contentsAlign = ContentsAlign.basic,
     ConnectionDirection connectionDirection = ConnectionDirection.after,
-    IndexedWidgetBuilder? contentsBuilder,
-    IndexedWidgetBuilder? oppositeContentsBuilder,
-    IndexedWidgetBuilder? indicatorBuilder,
+    NullableIndexedWidgetBuilder? contentsBuilder,
+    NullableIndexedWidgetBuilder? oppositeContentsBuilder,
+    NullableIndexedWidgetBuilder? indicatorBuilder,
     ConnectedConnectorBuilder? connectorBuilder,
     WidgetBuilder? firstConnectorBuilder,
     WidgetBuilder? lastConnectorBuilder,
@@ -237,8 +237,8 @@ class TimelineTileBuilder {
   factory TimelineTileBuilder.connectedFromStyle({
     @required required int itemCount,
     ConnectionDirection connectionDirection = ConnectionDirection.after,
-    IndexedWidgetBuilder? contentsBuilder,
-    IndexedWidgetBuilder? oppositeContentsBuilder,
+    NullableIndexedWidgetBuilder? contentsBuilder,
+    NullableIndexedWidgetBuilder? oppositeContentsBuilder,
     ContentsAlign contentsAlign = ContentsAlign.basic,
     IndexedValueBuilder<IndicatorStyle>? indicatorStyleBuilder,
     IndexedValueBuilder<ConnectorStyle>? connectorStyleBuilder,
@@ -290,8 +290,8 @@ class TimelineTileBuilder {
   ///  * [ContentsAlign]
   factory TimelineTileBuilder.fromStyle({
     required int itemCount,
-    IndexedWidgetBuilder? contentsBuilder,
-    IndexedWidgetBuilder? oppositeContentsBuilder,
+    NullableIndexedWidgetBuilder? contentsBuilder,
+    NullableIndexedWidgetBuilder? oppositeContentsBuilder,
     ContentsAlign contentsAlign = ContentsAlign.basic,
     IndicatorStyle indicatorStyle = IndicatorStyle.dot,
     ConnectorStyle connectorStyle = ConnectorStyle.solidLine,
@@ -333,15 +333,15 @@ class TimelineTileBuilder {
   factory TimelineTileBuilder({
     required int itemCount,
     ContentsAlign contentsAlign = ContentsAlign.basic,
-    IndexedWidgetBuilder? contentsBuilder,
-    IndexedWidgetBuilder? oppositeContentsBuilder,
-    IndexedWidgetBuilder? indicatorBuilder,
-    IndexedWidgetBuilder? startConnectorBuilder,
-    IndexedWidgetBuilder? endConnectorBuilder,
+    NullableIndexedWidgetBuilder? contentsBuilder,
+    NullableIndexedWidgetBuilder? oppositeContentsBuilder,
+    NullableIndexedWidgetBuilder? indicatorBuilder,
+    NullableIndexedWidgetBuilder? startConnectorBuilder,
+    NullableIndexedWidgetBuilder? endConnectorBuilder,
     double? itemExtent,
     IndexedValueBuilder<double>? itemExtentBuilder,
     IndexedValueBuilder<double>? nodePositionBuilder,
-    IndexedValueBuilder<bool>? nodeItemOverlapBuilder,
+    IndexedValueBuilder<bool?>? nodeItemOverlapBuilder,
     IndexedValueBuilder<double>? indicatorPositionBuilder,
     IndexedValueBuilder<TimelineThemeData>? themeBuilder,
   }) {
@@ -404,7 +404,7 @@ class TimelineTileBuilder {
     return _builder(context, index);
   }
 
-  static IndexedWidgetBuilder _createConnectedStartConnectorBuilder({
+  static NullableIndexedWidgetBuilder _createConnectedStartConnectorBuilder({
     ConnectionDirection? connectionDirection,
     WidgetBuilder? firstConnectorBuilder,
     ConnectedConnectorBuilder? connectorBuilder,
@@ -414,21 +414,19 @@ class TimelineTileBuilder {
           if (firstConnectorBuilder != null) {
             return firstConnectorBuilder.call(context);
           } else {
-            return SizedBox();
+            return null;
           }
         }
 
         if (connectionDirection == ConnectionDirection.before) {
-          return connectorBuilder?.call(context, index, ConnectorType.start) ??
-              const SizedBox();
+          return connectorBuilder?.call(context, index, ConnectorType.start);
         } else {
           return connectorBuilder?.call(
-                  context, index - 1, ConnectorType.start) ??
-              const SizedBox();
+              context, index - 1, ConnectorType.start);
         }
       };
 
-  static IndexedWidgetBuilder _createConnectedEndConnectorBuilder({
+  static NullableIndexedWidgetBuilder _createConnectedEndConnectorBuilder({
     ConnectionDirection? connectionDirection,
     WidgetBuilder? lastConnectorBuilder,
     ConnectedConnectorBuilder? connectorBuilder,
@@ -439,40 +437,35 @@ class TimelineTileBuilder {
           if (lastConnectorBuilder != null) {
             return lastConnectorBuilder.call(context);
           } else {
-            return const SizedBox();
+            return null;
           }
         }
 
         if (connectionDirection == ConnectionDirection.before) {
-          return connectorBuilder?.call(
-                  context, index + 1, ConnectorType.end) ??
-              const SizedBox();
+          return connectorBuilder?.call(context, index + 1, ConnectorType.end);
         } else {
-          return connectorBuilder?.call(context, index, ConnectorType.end) ??
-              const SizedBox();
+          return connectorBuilder?.call(context, index, ConnectorType.end);
         }
       };
 
-  static IndexedWidgetBuilder _createAlignedContentsBuilder({
+  static NullableIndexedWidgetBuilder _createAlignedContentsBuilder({
     required ContentsAlign align,
-    IndexedWidgetBuilder? contentsBuilder,
-    IndexedWidgetBuilder? oppositeContentsBuilder,
+    NullableIndexedWidgetBuilder? contentsBuilder,
+    NullableIndexedWidgetBuilder? oppositeContentsBuilder,
   }) {
     return (context, index) {
       switch (align) {
         case ContentsAlign.alternating:
           if (index.isOdd) {
-            return oppositeContentsBuilder?.call(context, index) ??
-                const SizedBox();
+            return oppositeContentsBuilder?.call(context, index);
           }
 
-          return contentsBuilder?.call(context, index) ?? const SizedBox();
+          return contentsBuilder?.call(context, index);
         case ContentsAlign.reverse:
-          return oppositeContentsBuilder?.call(context, index) ??
-              const SizedBox();
+          return oppositeContentsBuilder?.call(context, index);
         case ContentsAlign.basic:
         default:
-          return contentsBuilder?.call(context, index) ?? const SizedBox();
+          return contentsBuilder?.call(context, index);
       }
     };
   }
@@ -534,7 +527,7 @@ int _kDefaultSemanticIndexCallback(Widget _, int localIndex) => localIndex;
 ///  with semantic indexes.
 class TimelineTileBuilderDelegate extends SliverChildBuilderDelegate {
   TimelineTileBuilderDelegate(
-    IndexedWidgetBuilder builder, {
+    NullableIndexedWidgetBuilder builder, {
     ChildIndexGetter? findChildIndexCallback,
     int? childCount,
     bool addAutomaticKeepAlives = true,

--- a/lib/src/timelines.dart
+++ b/lib/src/timelines.dart
@@ -39,26 +39,26 @@ class Timeline extends BoxScrollView {
   /// are planning to change child order at a
   /// later time, consider using [Timeline] or [Timeline.custom].
   factory Timeline.tileBuilder({
-    Key key,
-    @required TimelineTileBuilder builder,
-    Axis scrollDirection,
+    Key? key,
+    required TimelineTileBuilder builder,
+    Axis? scrollDirection,
     bool reverse = false,
-    ScrollController controller,
-    bool primary,
-    ScrollPhysics physics,
+    ScrollController? controller,
+    bool? primary,
+    ScrollPhysics? physics,
     bool shrinkWrap = false,
-    EdgeInsetsGeometry padding,
+    EdgeInsetsGeometry? padding,
     // double itemExtent, TODO: fixedExtentTileBuilder?
-    double cacheExtent,
-    int semanticChildCount,
+    double? cacheExtent,
+    int? semanticChildCount,
     DragStartBehavior dragStartBehavior = DragStartBehavior.start,
     ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
         ScrollViewKeyboardDismissBehavior.manual,
-    String restorationId,
+    String? restorationId,
     Clip clipBehavior = Clip.hardEdge,
-    TimelineThemeData theme,
+    TimelineThemeData? theme,
   }) {
-    assert(builder.itemCount == null || builder.itemCount >= 0);
+    assert(builder.itemCount >= 0);
     assert(
         semanticChildCount == null || semanticChildCount <= builder.itemCount);
     return Timeline.custom(
@@ -104,27 +104,27 @@ class Timeline extends BoxScrollView {
   /// `addSemanticIndexes` argument corresponds to the
   /// [SliverChildListDelegate.addSemanticIndexes] property. None may be null.
   Timeline({
-    Key key,
-    Axis scrollDirection,
+    Key? key,
+    Axis? scrollDirection,
     bool reverse = false,
-    ScrollController controller,
-    bool primary,
-    ScrollPhysics physics,
+    ScrollController? controller,
+    bool? primary,
+    ScrollPhysics? physics,
     bool shrinkWrap = false,
-    EdgeInsetsGeometry padding,
+    EdgeInsetsGeometry? padding,
     this.itemExtent,
     bool addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     bool addSemanticIndexes = true,
-    double cacheExtent,
+    double? cacheExtent,
     List<Widget> children = const <Widget>[],
-    int semanticChildCount,
+    int? semanticChildCount,
     DragStartBehavior dragStartBehavior = DragStartBehavior.start,
     ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
         ScrollViewKeyboardDismissBehavior.manual,
-    String restorationId,
+    String? restorationId,
     Clip clipBehavior = Clip.hardEdge,
-    TimelineThemeData theme,
+    TimelineThemeData? theme,
   })  : childrenDelegate = SliverChildListDelegate(
           children,
           addAutomaticKeepAlives: addAutomaticKeepAlives,
@@ -183,29 +183,29 @@ class Timeline extends BoxScrollView {
   /// are planning to change child order at a
   /// later time, consider using [Timeline] or [Timeline.custom].
   Timeline.builder({
-    Key key,
-    Axis scrollDirection,
+    Key? key,
+    Axis? scrollDirection,
     bool reverse = false,
-    ScrollController controller,
-    bool primary,
-    ScrollPhysics physics,
+    ScrollController? controller,
+    bool? primary,
+    ScrollPhysics? physics,
     bool shrinkWrap = false,
-    EdgeInsetsGeometry padding,
+    EdgeInsetsGeometry? padding,
     this.itemExtent,
-    @required IndexedWidgetBuilder itemBuilder,
-    @required int itemCount,
+    required IndexedWidgetBuilder itemBuilder,
+    required int itemCount,
     bool addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     bool addSemanticIndexes = true,
-    double cacheExtent,
-    int semanticChildCount,
+    double? cacheExtent,
+    int? semanticChildCount,
     DragStartBehavior dragStartBehavior = DragStartBehavior.start,
     ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
         ScrollViewKeyboardDismissBehavior.manual,
-    String restorationId,
+    String? restorationId,
     Clip clipBehavior = Clip.hardEdge,
-    TimelineThemeData theme,
-  })  : assert(itemCount == null || itemCount >= 0),
+    TimelineThemeData? theme,
+  })  : assert(itemCount >= 0),
         assert(semanticChildCount == null || semanticChildCount <= itemCount),
         assert(scrollDirection == null || theme == null,
             'Cannot provide both a scrollDirection and a theme.'),
@@ -243,26 +243,25 @@ class Timeline extends BoxScrollView {
   ///
   ///  * This works similarly to [ListView.custom].
   Timeline.custom({
-    Key key,
-    Axis scrollDirection,
+    Key? key,
+    Axis? scrollDirection,
     bool reverse = false,
-    ScrollController controller,
-    bool primary,
-    ScrollPhysics physics,
+    ScrollController? controller,
+    bool? primary,
+    ScrollPhysics? physics,
     bool shrinkWrap = false,
-    EdgeInsetsGeometry padding,
+    EdgeInsetsGeometry? padding,
     this.itemExtent,
-    @required this.childrenDelegate,
-    double cacheExtent,
-    int semanticChildCount,
+    required this.childrenDelegate,
+    double? cacheExtent,
+    int? semanticChildCount,
     DragStartBehavior dragStartBehavior = DragStartBehavior.start,
     ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
         ScrollViewKeyboardDismissBehavior.manual,
-    String restorationId,
+    String? restorationId,
     Clip clipBehavior = Clip.hardEdge,
-    TimelineThemeData theme,
-  })  : assert(childrenDelegate != null),
-        assert(scrollDirection == null || theme == null,
+    TimelineThemeData? theme,
+  })  : assert(scrollDirection == null || theme == null,
             'Cannot provide both a scrollDirection and a theme.'),
         this.theme = theme,
         super(
@@ -289,7 +288,7 @@ class Timeline extends BoxScrollView {
   /// determine their own extent because the scrolling machinery can make use
   /// of the foreknowledge of the children's extent to save work, for example
   /// when the scroll position changes drastically.
-  final double itemExtent;
+  final double? itemExtent;
 
   /// A delegate that provides the children for the [Timeline].
   ///
@@ -304,7 +303,7 @@ class Timeline extends BoxScrollView {
   ///
   /// The default value of this property is the value of
   /// [TimelineThemeData.vertical()].
-  final TimelineThemeData theme;
+  final TimelineThemeData? theme;
 
   @override
   Widget buildChildLayout(BuildContext context) {
@@ -312,7 +311,7 @@ class Timeline extends BoxScrollView {
     if (itemExtent != null) {
       result = SliverFixedExtentList(
         delegate: childrenDelegate,
-        itemExtent: itemExtent,
+        itemExtent: itemExtent!,
       );
     } else {
       result = SliverList(delegate: childrenDelegate);
@@ -341,16 +340,15 @@ class Timeline extends BoxScrollView {
 class FixedTimeline extends StatelessWidget {
   /// Creates a timeline flex layout.
   factory FixedTimeline.tileBuilder({
-    Key key,
-    @required TimelineTileBuilder builder,
-    TimelineThemeData theme,
-    Axis direction,
+    Key? key,
+    required TimelineTileBuilder builder,
+    TimelineThemeData? theme,
+    Axis? direction,
     MainAxisSize mainAxisSize = MainAxisSize.max,
-    TextDirection textDirection,
+    TextDirection? textDirection,
     VerticalDirection verticalDirection = VerticalDirection.down,
     Clip clipBehavior = Clip.none,
   }) {
-    assert(builder != null);
     // TODO: how remove Builders?
     return FixedTimeline(
       children: [
@@ -378,7 +376,7 @@ class FixedTimeline extends StatelessWidget {
   /// to disambiguate `start` or `end` values for the main or cross axis
   /// directions, the [textDirection] must not be null.
   const FixedTimeline({
-    Key key,
+    Key? key,
     this.theme,
     this.direction,
     this.mainAxisSize = MainAxisSize.max,
@@ -388,9 +386,6 @@ class FixedTimeline extends StatelessWidget {
     this.children = const [],
   })  : assert(direction == null || theme == null,
             'Cannot provide both a direction and a theme.'),
-        assert(mainAxisSize != null),
-        assert(verticalDirection != null),
-        assert(clipBehavior != null),
         super(key: key);
 
   /// Default visual properties, like colors, size and spaces, for this
@@ -398,10 +393,10 @@ class FixedTimeline extends StatelessWidget {
   ///
   /// The default value of this property is the value of
   /// [TimelineThemeData.vertical()].
-  final TimelineThemeData theme;
+  final TimelineThemeData? theme;
 
   /// The direction to use as the main axis.
-  final Axis direction;
+  final Axis? direction;
 
   /// The widgets below this widget in the tree.
   ///
@@ -443,7 +438,7 @@ class FixedTimeline extends StatelessWidget {
   /// If the [direction] is [Axis.horizontal], and there's more than one child,
   /// then the [textDirection] (or the ambient [Directionality]) must not
   /// be null.
-  final TextDirection textDirection;
+  final TextDirection? textDirection;
 
   /// Determines the order to lay children out vertically and how to interpret
   /// `start` and `end` in the vertical direction.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/chulwoo-park/timelines/
 issue_tracker: https://github.com/chulwoo-park/timelines/issues
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
This PR closes #31 .

I followed the steps mentioned on [this page](https://dart.dev/null-safety/migration-guide).

Some points to mention :
- `Widget`-returning functions which returned `null` now return `const SizedBox()`, which is an empty `Widget`
- as tere is not many tests for this plugin, we could use some more manual testing